### PR TITLE
Check "ll" length specifier before "l"

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -135,7 +135,7 @@ fn take_conversion_specifier(s: &str) -> Result<(ConversionSpecifier, &str)> {
         s = s2;
     }
     // check length specifier
-    for len_spec in ["hh", "h", "l", "ll", "q", "L", "j", "z", "Z", "t"] {
+    for len_spec in ["hh", "h", "ll", "l", "q", "L", "j", "z", "Z", "t"] {
         if s.starts_with(len_spec) {
             s = s.strip_prefix(len_spec).ok_or(PrintfError::ParseError)?;
             break; // only allow one length specifier

--- a/tests/compare_to_libc.rs
+++ b/tests/compare_to_libc.rs
@@ -63,6 +63,7 @@ fn test_int() {
     check_fmt("%lX", -4_i64);
     check_fmt("%ld", 48_i64);
     check_fmt("%-8hd", -12_i16);
+    check_fmt("%llx", 0x0123456789abcdef_u64);
 }
 
 #[test]


### PR DESCRIPTION
The "l" length specifier might match the first character of "ll" so look for "ll" first.