### PR TITLE
Expose `parse_format_string` to external users to allow for attempting to typecast raw data

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ mod format;
 mod parser;
 
 pub use format::Printf;
-use parser::{parse_format_string, FormatElement};
+pub use parser::{parse_format_string, FormatElement};
 pub use parser::{ConversionSpecifier, ConversionType, NumericParam};
 
 /// Error type

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,7 +1,7 @@
 use crate::{PrintfError, Result};
 
 #[derive(Debug, Clone)]
-pub(crate) enum FormatElement {
+pub enum FormatElement {
     Verbatim(String),
     Format(ConversionSpecifier),
 }
@@ -69,7 +69,7 @@ pub enum ConversionType {
     PercentSign,
 }
 
-pub(crate) fn parse_format_string(fmt: &str) -> Result<Vec<FormatElement>> {
+pub fn parse_format_string(fmt: &str) -> Result<Vec<FormatElement>> {
     // find the first %
     let mut res = Vec::new();
     let parts: Vec<&str> = fmt.splitn(2, '%').collect();

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -77,21 +77,22 @@ pub enum ConversionType {
 ///     let fmt = "Hello %#06x";
 ///     let parsed = parse_format_string(fmt).unwrap();
 ///     assert_eq!(
-///        parsed,
-///        vec![
-///           FormatElement::Verbatim("Hello ".to_owned()),
-///           FormatElement::Format(ConversionSpecifier {
-///             alt_form: true,
-///             zero_pad: false,
-///             left_adj: false,
-///             space_sign: false,
-///             force_sign: false,
-///             width: NumericParam::Literal(6),
-///             precision: NumericParam::Literal(6),
-///             conversion_type: ConversionType::HexIntLower,
-///          }),
-///       ]
-///    );
+///         parsed,
+///         vec![
+///             FormatElement::Verbatim("Hello ".to_owned()),
+///             FormatElement::Format(ConversionSpecifier {
+///                 alt_form: true,
+///                 zero_pad: true,
+///                 left_adj: false,
+///                 space_sign: false,
+///                 force_sign: false,
+///                 width: NumericParam::Literal(6),
+///                 precision: NumericParam::Literal(6),
+///                 conversion_type: ConversionType::HexIntLower,
+///             }),
+///         ]
+///     );
+/// 
 ///
 pub fn parse_format_string(fmt: &str) -> Result<Vec<FormatElement>> {
     // find the first %

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -69,6 +69,30 @@ pub enum ConversionType {
     PercentSign,
 }
 
+/// Parses a string to a vector of [FormatElement]
+///
+/// Takes a printf-style format string `fmt`
+///
+///     use sprintf::{parse_format_string, FormatElement, ConversionType, ConversionSpecifier};
+///     let fmt = "Hello %#06x";
+///     let parsed = parse_format_string(fmt).unwrap();
+///     assert_eq!(
+///        parsed,
+///        vec![
+///           FormatElement::Verbatim("Hello ".to_owned()),
+///           FormatElement::Format(ConversionSpecifier {
+///             alt_form: true,
+///             zero_pad: false,
+///             left_adj: false,
+///             space_sign: false,
+///             force_sign: false,
+///             width: NumericParam::Literal(6),
+///             precision: NumericParam::Literal(6),
+///             conversion_type: ConversionType::HexIntLower,
+///          }),
+///      ]
+///    );
+///
 pub fn parse_format_string(fmt: &str) -> Result<Vec<FormatElement>> {
     // find the first %
     let mut res = Vec::new();

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,13 +1,13 @@
 use crate::{PrintfError, Result};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FormatElement {
     Verbatim(String),
     Format(ConversionSpecifier),
 }
 
 /// Parsed printf conversion specifier
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ConversionSpecifier {
     /// flag `#`: use `0x`, etc?
     pub alt_form: bool,
@@ -73,26 +73,20 @@ pub enum ConversionType {
 ///
 /// Takes a printf-style format string `fmt`
 ///
-///     use sprintf::{parse_format_string, FormatElement, ConversionType, ConversionSpecifier};
+///     use sprintf::{parse_format_string, FormatElement, ConversionType, ConversionSpecifier, NumericParam};
 ///     let fmt = "Hello %#06x";
 ///     let parsed = parse_format_string(fmt).unwrap();
-///     assert_eq!(
-///         parsed,
-///         vec![
-///             FormatElement::Verbatim("Hello ".to_owned()),
-///             FormatElement::Format(ConversionSpecifier {
-///                 alt_form: true,
-///                 zero_pad: true,
-///                 left_adj: false,
-///                 space_sign: false,
-///                 force_sign: false,
-///                 width: NumericParam::Literal(6),
-///                 precision: NumericParam::Literal(6),
-///                 conversion_type: ConversionType::HexIntLower,
-///             }),
-///         ]
-///     );
-/// 
+///     assert_eq!(parsed[0], FormatElement::Verbatim("Hello ".to_owned()));
+///     assert_eq!(parsed[1], FormatElement::Format(ConversionSpecifier {
+///         alt_form: true,
+///         zero_pad: true,
+///         left_adj: false,
+///         space_sign: false,
+///         force_sign: false,
+///         width: NumericParam::Literal(6),
+///         precision: NumericParam::Literal(6),
+///         conversion_type: ConversionType::HexIntLower,
+///     }));
 ///
 pub fn parse_format_string(fmt: &str) -> Result<Vec<FormatElement>> {
     // find the first %

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -90,7 +90,7 @@ pub enum ConversionType {
 ///             precision: NumericParam::Literal(6),
 ///             conversion_type: ConversionType::HexIntLower,
 ///          }),
-///      ]
+///       ]
 ///    );
 ///
 pub fn parse_format_string(fmt: &str) -> Result<Vec<FormatElement>> {


### PR DESCRIPTION
Heya, very neat to have this module!

We don't have the correct types initially for e.g. `char` types, as we're using this for compressed logging, so all of our "arguments" start out as `u8` types, and we don't have the original type available for each argument. By exposing the format parts, we get to use them to attempt to create / typecast the different arguments to the correct types to then finally cast as `&dyn Printf`.