### PR TITLE
Support more std types

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -236,7 +236,13 @@ impl Printf for i8 {
 impl Printf for u8 {
     fn format(&self, spec: &ConversionSpecifier) -> Result<String> {
         match spec.conversion_type {
-            ConversionType::Char => char::from(*self).format(spec),
+            ConversionType::Char => {
+                if self.is_ascii() {
+                    char::from(*self).format(spec)
+                } else {
+                    Err(PrintfError::WrongType)
+                }
+            }
             _ => (*self as u64).format(spec),
         }
     }

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,4 +1,5 @@
 use std::convert::{TryFrom, TryInto};
+use std::ffi::{CStr, CString};
 
 use crate::{
     parser::{ConversionSpecifier, ConversionType, NumericParam},
@@ -493,6 +494,28 @@ impl Printf for char {
 impl Printf for String {
     fn format(&self, spec: &ConversionSpecifier) -> Result<String> {
         (self as &str).format(spec)
+    }
+    fn as_int(&self) -> Option<i32> {
+        None
+    }
+}
+
+impl Printf for &CStr {
+    fn format(&self, spec: &ConversionSpecifier) -> Result<String> {
+        if let Ok(s) = self.to_str() {
+            s.format(spec)
+        } else {
+            Err(PrintfError::WrongType)
+        }
+    }
+    fn as_int(&self) -> Option<i32> {
+        None
+    }
+}
+
+impl Printf for CString {
+    fn format(&self, spec: &ConversionSpecifier) -> Result<String> {
+        self.as_c_str().format(spec)
     }
     fn as_int(&self) -> Option<i32> {
         None

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ use parser::{parse_format_string, FormatElement};
 pub use parser::{ConversionSpecifier, ConversionType, NumericParam};
 
 /// Error type
-#[derive(Debug, Clone, Copy, Error)]
+#[derive(Debug, Clone, Copy, Error, PartialEq, Eq)]
 pub enum PrintfError {
     /// Error parsing the format string
     #[error("Error parsing the format string")]

--- a/tests/compare_to_libc.rs
+++ b/tests/compare_to_libc.rs
@@ -102,6 +102,9 @@ fn test_float() {
 fn test_str() {
     check_fmt_s("test %% with string: %s yay\n", "FOO");
     check_fmt("test char %c", '~');
+    let c_string = CString::new("test").unwrap();
+    check_fmt("%s", c_string.as_c_str());
+    check_fmt("%s", c_string);
 }
 
 #[test]

--- a/tests/compare_to_libc.rs
+++ b/tests/compare_to_libc.rs
@@ -125,3 +125,11 @@ fn test_char() {
     check_fmt("%c", u16::try_from('x').unwrap());
     check_fmt("%c", u32::try_from('x').unwrap());
 }
+
+#[test]
+fn test_sanity() {
+    // u8 must not misinterpret bytes from multi-byte UTF-8 characters
+    let bytes = "∆".as_bytes();
+    assert!(bytes.len() > 1);
+    assert_eq!(sprintf!("%c", bytes[0]), Err(PrintfError::WrongType));
+}

--- a/tests/compare_to_libc.rs
+++ b/tests/compare_to_libc.rs
@@ -1,4 +1,4 @@
-use std::convert::TryInto;
+use std::convert::{TryFrom, TryInto};
 use std::ffi::CString;
 use std::os::raw::c_char;
 
@@ -102,4 +102,13 @@ fn test_float() {
 fn test_str() {
     check_fmt_s("test %% with string: %s yay\n", "FOO");
     check_fmt("test char %c", '~');
+}
+
+#[test]
+fn test_char() {
+    check_fmt("%c", 'x');
+    check_fmt("%c", b'x');
+    check_fmt("%c", b'x' as c_char);
+    check_fmt("%c", u16::try_from('x').unwrap());
+    check_fmt("%c", u32::try_from('x').unwrap());
 }


### PR DESCRIPTION
Add support for char types that contain utf8: `u8`, `c_char`, `u16`, `u32`
Add support for C string types that contain utf8: `CStr`, `CString`

Closes #6
