### PR TITLE
Performance optimisations

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -6,9 +6,9 @@ use crate::{PrintfError, Result};
 /// verbatim, or a format specifier that should be replaced based on an argument
 /// to the [vsprintf](crate::vsprintf) call.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum FormatElement {
+pub enum FormatElement<'a> {
     /// Some characters that are copied to the output as-is
-    Verbatim(String),
+    Verbatim(&'a str),
     /// A format specifier
     Format(ConversionSpecifier),
 }
@@ -103,14 +103,17 @@ pub enum ConversionType {
 pub fn parse_format_string(fmt: &str) -> Result<Vec<FormatElement>> {
     // find the first %
     let mut res = Vec::new();
-    let parts: Vec<&str> = fmt.splitn(2, '%').collect();
-    if !parts[0].is_empty() {
-        res.push(FormatElement::Verbatim(parts[0].to_owned()));
-    }
-    if parts.len() > 1 {
-        let (spec, rest) = take_conversion_specifier(parts[1])?;
+
+    if let Some((verbatim_prefix, rest)) = fmt.split_once('%') {
+        if !verbatim_prefix.is_empty() {
+            res.push(FormatElement::Verbatim(verbatim_prefix));
+        }
+        let (spec, rest) = take_conversion_specifier(rest)?;
         res.push(FormatElement::Format(spec));
         res.append(&mut parse_format_string(rest)?);
+        return Ok(res);
+    } else if !fmt.is_empty() {
+        res.push(FormatElement::Verbatim(fmt));
     }
 
     Ok(res)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -104,16 +104,20 @@ pub fn parse_format_string(fmt: &str) -> Result<Vec<FormatElement>> {
     // find the first %
     let mut res = Vec::new();
 
-    if let Some((verbatim_prefix, rest)) = fmt.split_once('%') {
-        if !verbatim_prefix.is_empty() {
-            res.push(FormatElement::Verbatim(verbatim_prefix));
+    let mut rem = fmt;
+
+    while !rem.is_empty() {
+        if let Some((verbatim_prefix, rest)) = rem.split_once('%') {
+            if !verbatim_prefix.is_empty() {
+                res.push(FormatElement::Verbatim(verbatim_prefix));
+            }
+            let (spec, rest) = take_conversion_specifier(rest)?;
+            res.push(FormatElement::Format(spec));
+            rem = rest;
+        } else {
+            res.push(FormatElement::Verbatim(rem));
+            break;
         }
-        let (spec, rest) = take_conversion_specifier(rest)?;
-        res.push(FormatElement::Format(spec));
-        res.append(&mut parse_format_string(rest)?);
-        return Ok(res);
-    } else if !fmt.is_empty() {
-        res.push(FormatElement::Verbatim(fmt));
     }
 
     Ok(res)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -85,7 +85,7 @@ pub enum ConversionType {
 ///     };
 ///     let fmt = "Hello %#06x";
 ///     let parsed = parse_format_string(fmt).unwrap();
-///     assert_eq!(parsed[0], FormatElement::Verbatim("Hello ".to_owned()));
+///     assert_eq!(parsed[0], FormatElement::Verbatim("Hello "));
 ///     assert_eq!(
 ///         parsed[1],
 ///         FormatElement::Format(ConversionSpecifier {


### PR DESCRIPTION
This PR consists of two commits, both of which make significant performance improvements to the parser. The first commit also makes a small API change by changing the type of `FormatElement::Verbatim`'s field from `String` to `&str` and introducing a generic lifetime onto `FormatElement`.

I used the following test to benchmark the changes:

```rust
#[test]
fn perf_test() {
    let repeating_fmt_str = "test%utest%sing";
    let repeating_arg = 42;
    let repeating_arg_str = "foo";
    let fmt_str = {
        let mut s = String::new();
        for _ in 0..1000 {
            s.push_str(repeating_fmt_str);
        }
        s
    };
    let fmt_args: Vec<&dyn Printf> = {
        let mut v: Vec<&dyn Printf> = Vec::new();
        for _ in 0..1000 {
            v.push(&repeating_arg);
            v.push(&repeating_arg_str);
        }
        v
    };

    let start = std::time::Instant::now();
    for _ in 0..1000 {
        vsprintf(&fmt_str, &fmt_args).unwrap();
    }
    let end = std::time::Instant::now();
    eprintln!("took {:?}", end - start);
}
```

The test just formats a large string 1000 times and measures the time taken. This was just to get a rough idea of whether the changes improved performance, not to get precise impartial measurements.
I ran it like this:
```
$ cargo test --release perf_test -- --nocapture
```

On my laptop (amd64, linux, rust 1.81.0), the formatting part of the test takes ~8.8 seconds on v0.3.1. After the first commit (which is focused on reducing allocations), this comes down to ~2.7 seconds. After the second commit (which replaces the top-level recursion in the parser with a loop), this drops further to ~0.27 seconds. So overall, approximately a 30x performance increase.

The benchmark above focuses on longer format strings to try to mitigate some of the test overhead, but performance is improved even for shorter ones. Changing the benchmark above to only 2 iterations of the repeating format string and args and repeating the formatting 100,000 times gives me ~140 milliseconds on v0.3.1 and ~85 milliseconds after both commits.