### PR TITLE
bump thiserror dependency to version 2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["template-engine", "wasm"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-thiserror = "1.0.57"
+thiserror = "2.0"
 
 [dev-dependencies]
 libc = "0.2"


### PR DESCRIPTION
Surprisingly, this seems to require no code changes.