### PR TITLE
add support for truncating string arguments

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -131,7 +131,7 @@ fn take_conversion_specifier(s: &str) -> Result<(ConversionSpecifier, &str)> {
         space_sign: false,
         force_sign: false,
         width: NumericParam::Literal(0),
-        precision: NumericParam::Literal(6),
+        precision: NumericParam::FromArgument, // Placeholder - must not be returned!
         // ignore length modifier
         conversion_type: ConversionType::DecInt,
     };
@@ -202,6 +202,18 @@ fn take_conversion_specifier(s: &str) -> Result<(ConversionSpecifier, &str)> {
             return Err(PrintfError::ParseError);
         }
     };
+
+    if spec.precision == NumericParam::FromArgument {
+        // If precision is not specified, set to default value
+        let p = if spec.conversion_type == ConversionType::String {
+            // Default to max limit (aka no limit) for strings
+            i32::MAX
+        } else {
+            // Default to 6 for all other types
+            6
+        };
+        spec.precision = NumericParam::Literal(p);
+    }
 
     Ok((spec, &s[1..]))
 }

--- a/tests/compare_to_libc.rs
+++ b/tests/compare_to_libc.rs
@@ -112,6 +112,10 @@ fn test_float() {
 #[test]
 fn test_str() {
     check_fmt_s("test %% with string: %s yay\n", "FOO");
+    check_fmt_s(
+        "%s",
+        "testing with a slightly longer string to make sure it doesn't truncate",
+    );
     check_fmt("test char %c", '~');
     let c_string = CString::new("test").unwrap();
     check_fmt("%s", c_string.as_c_str());
@@ -120,6 +124,20 @@ fn test_str() {
     check_fmt_s("%4s", "𒀀"); // multi-byte character test (4 bytes)
     check_fmt_s("%-4sX", "A");
     check_fmt_s("%-4sX", "𒀀"); // multi-byte character test (4 bytes)
+    check_fmt_s("%1.3s", "ABCDEFG");
+    check_fmt_s("%1.4s", "𒀀𒀀"); // multi-byte character test (4 bytes per char)
+    check_fmt_s("%8.4s", "ABCDEFG");
+
+    // glibc does not handle UTF-8 strings correctly when truncating, but we cannot produce malformed UTF-8
+    // strings in Rust. Instead, we round down to the nearest character boundary.
+    assert_eq!(sprintf!("%1.1s", "𒀀𒀀𒀀").unwrap(), " ");
+    assert_eq!(sprintf!("%1.2s", "𒀀𒀀𒀀").unwrap(), " ");
+    assert_eq!(sprintf!("%1.3s", "𒀀𒀀𒀀").unwrap(), " ");
+    assert_eq!(sprintf!("%1.4s", "𒀀𒀀𒀀").unwrap(), "𒀀");
+    assert_eq!(sprintf!("%1.5s", "𒀀𒀀𒀀").unwrap(), "𒀀");
+    assert_eq!(sprintf!("%1.6s", "𒀀𒀀𒀀").unwrap(), "𒀀");
+    assert_eq!(sprintf!("%1.7s", "𒀀𒀀𒀀").unwrap(), "𒀀");
+    assert_eq!(sprintf!("%1.8s", "𒀀𒀀𒀀").unwrap(), "𒀀𒀀");
 }
 
 #[test]


### PR DESCRIPTION
Fixes #14.

There is a slight issue with compatibility with glibc here, since it will happily truncate in the middle of a multi-byte character. We must instead round lengths down to the nearest character boundary, since we cannot produce rust strings that contain invalid UTF-8.