### PR TITLE
Feature-gate standard library use

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,10 @@ categories = ["template-engine", "wasm"]
 
 [features]
 default = ["std"]
-std = []
+std = ["thiserror/std"]
 
 [dependencies]
-thiserror = "2.0"
+thiserror = { version = "2.0", default-features = false }
 
 [dev-dependencies]
 libc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,9 @@ repository = "https://github.com/tjol/sprintf-rs"
 keywords = ["printf", "text", "string"]
 categories = ["template-engine", "wasm"]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+default = ["std"]
+std = []
 
 [dependencies]
 thiserror = "2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,13 @@ keywords = ["printf", "text", "string"]
 categories = ["template-engine", "wasm"]
 
 [features]
-default = ["std"]
-std = ["thiserror/std"]
+default = ["thiserror/std", "num-traits/std"]
+no_std = ["num-traits/libm"]
 
 [dependencies]
+cfg-if = "1.0"
 thiserror = { version = "2.0", default-features = false }
+num-traits = { version = "0.2", default-features = false }
 
 [dev-dependencies]
 libc = "0.2"

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 This crate was created out of a desire to provide C printf-style formatting
 in a WASM program, where there is no libc.
 
-**Note:** *You're probably better off using standard Rust string formatting
-instead of this crate unless you specificaly need printf compatibility.*
+**Note:** _You're probably better off using standard Rust string formatting
+instead of this crate unless you specificaly need printf compatibility._
 
 This crate implements a dynamically type-checked function `vsprintf` and macro
 `sprintf!`.
@@ -20,5 +20,5 @@ assert_eq!(s, "3 + 9 = 12\n");
 ```
 
 `libc` is a dev dependency as it is used in the tests to compare results. This
-crate depends on `std` for string formatting, memory allocation, and
-floating-point maths.
+crate depends on `std` for providing an implementation for `CString` values as
+arguments, but this can be avoided by disabling the `std` feature.

--- a/README.md
+++ b/README.md
@@ -20,5 +20,5 @@ assert_eq!(s, "3 + 9 = 12\n");
 ```
 
 `libc` is a dev dependency as it is used in the tests to compare results. This
-crate depends on `std` for providing an implementation for `CString` values as
-arguments, but this can be avoided by disabling the `std` feature.
+crate depends on `std` by default, but the default features can be disabled and
+the `no_std` feature can be enabled as an alternative.

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,6 +1,7 @@
 use core::convert::{TryFrom, TryInto};
 use core::ffi::CStr;
 
+use crate::compat::*;
 use crate::{
     parser::{ConversionSpecifier, ConversionType, NumericParam},
     PrintfError, Result,
@@ -580,8 +581,7 @@ impl Printf for &CStr {
     }
 }
 
-#[cfg(feature = "std")]
-impl Printf for std::ffi::CString {
+impl Printf for CString {
     fn format(&self, spec: &ConversionSpecifier) -> Result<String> {
         self.as_c_str().format(spec)
     }

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,5 +1,5 @@
-use std::convert::{TryFrom, TryInto};
-use std::ffi::{CStr, CString};
+use core::convert::{TryFrom, TryInto};
+use core::ffi::CStr;
 
 use crate::{
     parser::{ConversionSpecifier, ConversionType, NumericParam},
@@ -580,7 +580,8 @@ impl Printf for &CStr {
     }
 }
 
-impl Printf for CString {
+#[cfg(not(feature = "std"))]
+impl Printf for std::ffi::CString {
     fn format(&self, spec: &ConversionSpecifier) -> Result<String> {
         self.as_c_str().format(spec)
     }

--- a/src/format.rs
+++ b/src/format.rs
@@ -580,7 +580,7 @@ impl Printf for &CStr {
     }
 }
 
-#[cfg(not(feature = "std"))]
+#[cfg(feature = "std")]
 impl Printf for std::ffi::CString {
     fn format(&self, spec: &ConversionSpecifier) -> Result<String> {
         self.as_c_str().format(spec)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(feature = "no_std", no_std)]
+
 //! Libc s(n)printf clone written in Rust, so you can use printf-style
 //! formatting without a libc (e.g. in WebAssembly).
 //!
@@ -25,10 +27,33 @@ use thiserror::Error;
 mod format;
 pub mod parser;
 
+use compat::*;
 pub use format::Printf;
 use parser::{parse_format_string, FormatElement};
 #[doc(hidden)]
 pub use parser::{ConversionSpecifier, ConversionType, NumericParam};
+
+pub(crate) mod compat {
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "no_std")] {
+            extern crate alloc;
+
+            pub use alloc::ffi::CString;
+            pub use alloc::format;
+            pub use alloc::string::String;
+            pub use alloc::borrow::ToOwned;
+            pub use alloc::vec::Vec;
+
+            pub use num_traits::Float;
+        } else {
+            pub use std::ffi::CString;
+            pub use std::format;
+            pub use std::string::String;
+            pub use std::borrow::ToOwned;
+            pub use std::vec::Vec;
+        }
+    }
+}
 
 /// Error type
 #[derive(Debug, Clone, Copy, Error, PartialEq, Eq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@ pub enum PrintfError {
     Unknown,
 }
 
-pub type Result<T> = std::result::Result<T, PrintfError>;
+pub type Result<T> = core::result::Result<T, PrintfError>;
 
 /// Format a string. (Roughly equivalent to `vsnprintf` or `vasprintf` in C)
 ///

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,5 +1,6 @@
 //! Parse printf format strings
 
+use crate::compat::*;
 use crate::{PrintfError, Result};
 
 /// A part of a format string: either a string of characters to be included


### PR DESCRIPTION
Closes #20. 

To use:

```toml
sprintf = { version = "x.y.z", features = ["no_std"], default-features = false }
```
